### PR TITLE
fix: avoid duplicate source requests for repeated keyword variants

### DIFF
--- a/src/idea_reality_mcp/sources/github.py
+++ b/src/idea_reality_mcp/sources/github.py
@@ -17,7 +17,7 @@ _GITHUB_AUTO_ADJECTIVES = {
     "legendary", "supreme", "verbose", "miniature", "psychic", "organic",
     "animated", "automatic", "bookish", "curly", "effective", "fantastic",
     "glowing", "humble", "ideal", "jubilant", "laughing", "musical",
-    "obscure", "probable", "probable", "scaling", "special", "upgraded",
+    "obscure", "probable", "scaling", "special", "upgraded",
     "vigilant", "literate", "cautious", "congenial", "didactic", "eloquent",
     "fictional", "improved", "symmetrical", "refactored", "reimagined",
 }
@@ -111,6 +111,10 @@ async def search_github_repos(keywords: list[str]) -> GitHubResults:
     Returns:
         Aggregated results with total count, max stars, and top 5 repos.
     """
+    normalized_keywords = list(dict.fromkeys(k.strip() for k in keywords if k.strip()))
+    if not normalized_keywords:
+        return GitHubResults(total_repo_count=0, max_stars=0, top_repos=[])
+
     max_total_count = 0
     max_stars = 0
     all_repos: list[dict] = []
@@ -123,7 +127,7 @@ async def search_github_repos(keywords: list[str]) -> GitHubResults:
     repo_query_hits: dict[str, int] = {}
 
     async with httpx.AsyncClient(timeout=15.0) as client:
-        for query in keywords:
+        for query in normalized_keywords:
             try:
                 resp = await client.get(
                     GITHUB_API,
@@ -172,7 +176,7 @@ async def search_github_repos(keywords: list[str]) -> GitHubResults:
     # Filter noise repos before ranking.
     # Build keyword list from query strings for relevance check.
     kw_set: set[str] = set()
-    for q in keywords:
+    for q in normalized_keywords:
         for w in q.lower().split():
             if len(w) >= 4:
                 kw_set.add(w)

--- a/src/idea_reality_mcp/sources/hn.py
+++ b/src/idea_reality_mcp/sources/hn.py
@@ -42,6 +42,10 @@ async def search_hn(keywords: list[str]) -> HNResults:
     Returns:
         Aggregated mention count and evidence items.
     """
+    normalized_keywords = list(dict.fromkeys(k.strip() for k in keywords if k.strip()))
+    if not normalized_keywords:
+        return HNResults(total_mentions=0, evidence=[])
+
     now = datetime.now(timezone.utc)
     twelve_months_ago = int((now - timedelta(days=365)).timestamp())
     three_months_ago = int((now - timedelta(days=90)).timestamp())
@@ -50,7 +54,7 @@ async def search_hn(keywords: list[str]) -> HNResults:
     evidence: list[dict] = []
 
     async with httpx.AsyncClient(timeout=15.0) as client:
-        for query in keywords:
+        for query in normalized_keywords:
             try:
                 resp = await client.get(
                     HN_ALGOLIA_API,

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -183,6 +183,29 @@ class TestSearchGitHubReposDeduplication:
         assert stars == sorted(stars, reverse=True)
 
 
+class TestSearchGitHubReposDuplicateKeywords:
+    @pytest.mark.asyncio
+    async def test_search_github_repos_ignores_duplicate_keywords(self):
+        """Do not issue duplicate API requests for repeated query variants."""
+        api_response = {
+            "total_count": 7,
+            "items": [_github_repo_item("owner/repo-a", stars=123)],
+        }
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(api_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.github.httpx.AsyncClient", return_value=mock_client):
+            result = await search_github_repos(["same query", "same query", "  same query  "])
+
+        assert isinstance(result, GitHubResults)
+        assert result.total_repo_count == 7
+        # 1 unique keyword -> 2 GitHub API calls (top repos + recent-created query)
+        assert mock_client.get.call_count == 2
+
+
 # ===========================================================================
 # Hacker News tests
 # ===========================================================================
@@ -280,3 +303,21 @@ class TestSearchHNMultipleKeywords:
         assert result.evidence[1]["count"] == 5
         assert result.evidence[2]["query"] == "kw3"
         assert result.evidence[2]["count"] == 20
+
+
+class TestSearchHNDuplicateKeywords:
+    @pytest.mark.asyncio
+    async def test_search_hn_ignores_duplicate_keywords(self):
+        """Do not query HN multiple times for repeated keyword variants."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response({"nbHits": 11, "hits": []})
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.hn.httpx.AsyncClient", return_value=mock_client):
+            result = await search_hn(["same", "same", " same "])
+
+        assert isinstance(result, HNResults)
+        assert result.total_mentions == 11
+        assert len(result.evidence) == 1
+        assert mock_client.get.call_count == 1


### PR DESCRIPTION
## What changed
- Deduplicated repeated keyword variants in `search_github_repos` and `search_hn` before issuing API requests.
- Added an early return for empty/whitespace-only keyword lists in both source adapters.
- Added regression tests to verify duplicate keyword inputs only trigger one outbound request per source:
  - `test_search_github_repos_ignores_duplicate_keywords`
  - `test_search_hn_ignores_duplicate_keywords`

## Why
- `extract_keywords` can intentionally repeat query variants when few usable terms are available.
- Without deduplication, repeated variants cause redundant network calls and inflate aggregate counts (`total_repo_count` / `total_mentions`), which can overstate competition signals.
- Deduplicating exact duplicate variants keeps scoring and evidence accurate while reducing unnecessary API traffic.

## Testing
- ✅ `pytest -q` (128 passed, 7 skipped)
