### PR TITLE
feat: add Stack Overflow as 6th data source (deep mode)

### DIFF
--- a/src/idea_reality_mcp/scoring/engine.py
+++ b/src/idea_reality_mcp/scoring/engine.py
@@ -12,6 +12,7 @@ from ..sources.hn import HNResults
 from ..sources.npm import NpmResults
 from ..sources.pypi import PyPIResults
 from ..sources.producthunt import ProductHuntResults
+from ..sources.stackoverflow import StackOverflowResults
 from .synonyms import INTENT_ANCHORS, SYNONYMS
 
 # ---------------------------------------------------------------------------
@@ -398,6 +399,7 @@ _K_GITHUB_STAR = 95 / math.log(10001)   # ~10.31  | 10→25, 500→64, 1000→71
 _K_HN = 95 / math.log(101)             # ~20.58  | 1→14, 15→57, 30→71, 100→95
 _K_NPM_PYPI = 95 / math.log(501)       # ~15.28  | 1→11, 20→47, 100→71, 500→95
 _K_PH = 95 / math.log(101)             # ~20.58  | 1→14, 10→49, 30→71, 100→95
+_K_SO = 95 / math.log(201)             # ~17.91  | 1→12, 20→54, 50→71, 200→95
 
 
 def _log_score(count: int, k: float) -> int:
@@ -432,6 +434,11 @@ def _pypi_score(count: int) -> int:
 def _ph_score(count: int) -> int:
     """Score Product Hunt product count."""
     return _log_score(count, _K_PH)
+
+
+def _so_score(count: int) -> int:
+    """Score Stack Overflow question count."""
+    return _log_score(count, _K_SO)
 
 
 def _filter_relevant_similars(
@@ -567,12 +574,13 @@ _QUICK_WEIGHTS = {
 }
 
 _DEEP_WEIGHTS = {
-    "github_repo": 0.25,
-    "github_star": 0.10,
-    "hn": 0.15,
-    "npm": 0.20,
-    "pypi": 0.15,
-    "ph": 0.15,
+    "github_repo": 0.22,
+    "github_star": 0.09,
+    "hn": 0.14,
+    "npm": 0.18,
+    "pypi": 0.13,
+    "ph": 0.14,
+    "so": 0.10,
 }
 
 
@@ -586,6 +594,7 @@ def compute_signal(
     npm_results: NpmResults | None = None,
     pypi_results: PyPIResults | None = None,
     ph_results: ProductHuntResults | None = None,
+    so_results: StackOverflowResults | None = None,
 ) -> dict:
     """Compute the full reality check output.
 
@@ -604,6 +613,7 @@ def compute_signal(
         n_score = 0
         p_score = 0
         ph_val = 0
+        so_val = 0
     else:
         # Deep mode
         n_score = _npm_score(npm_results.total_count) if npm_results else 0
@@ -624,20 +634,36 @@ def compute_signal(
         else:
             ph_val = 0
             # Redistribute PH weight proportionally to other deep sources
-            ph_w = weights.pop("ph", 0.15)
+            ph_w = weights.pop("ph", 0.14)
             remaining_keys = list(weights.keys())
             total_remaining = sum(weights[k] for k in remaining_keys)
             if total_remaining > 0:
                 for k in remaining_keys:
                     weights[k] += ph_w * (weights[k] / total_remaining)
 
+        # Stack Overflow — redistribute weight if unavailable
+        so_available = so_results is not None
+        if so_available:
+            so_val = _so_score(so_results.total_count)
+            sources_used.append("stackoverflow")
+        else:
+            so_val = 0
+            # Redistribute SO weight proportionally to other deep sources
+            so_w = weights.pop("so", 0.10)
+            remaining_keys = list(weights.keys())
+            total_remaining = sum(weights[k] for k in remaining_keys)
+            if total_remaining > 0:
+                for k in remaining_keys:
+                    weights[k] += so_w * (weights[k] / total_remaining)
+
         signal = int(
-            g_repo * weights.get("github_repo", 0.25)
-            + g_star * weights.get("github_star", 0.10)
-            + h_score * weights.get("hn", 0.15)
-            + n_score * weights.get("npm", 0.20)
-            + p_score * weights.get("pypi", 0.15)
+            g_repo * weights.get("github_repo", 0.22)
+            + g_star * weights.get("github_star", 0.09)
+            + h_score * weights.get("hn", 0.14)
+            + n_score * weights.get("npm", 0.18)
+            + p_score * weights.get("pypi", 0.13)
             + ph_val * weights.get("ph", 0)
+            + so_val * weights.get("so", 0)
         )
 
     # --- Temporal boost — market momentum from recent activity ratios ---
@@ -648,6 +674,8 @@ def compute_signal(
         temporal_ratios.append(hn_results.recent_mention_ratio)
     if ph_results is not None and not ph_results.skipped and ph_results.total_count > 0:
         temporal_ratios.append(ph_results.recent_launch_ratio)
+    if so_results is not None and so_results.recent_question_ratio is not None:
+        temporal_ratios.append(so_results.recent_question_ratio)
 
     if temporal_ratios:
         market_momentum = sum(temporal_ratios) / len(temporal_ratios)
@@ -692,6 +720,8 @@ def compute_signal(
         evidence.extend(pypi_results.evidence)
     if ph_results:
         evidence.extend(ph_results.evidence)
+    if so_results:
+        evidence.extend(so_results.evidence)
 
     # Temporal evidence
     if github_results.total_repo_count > 0:
@@ -717,6 +747,14 @@ def compute_signal(
             "query": keywords[0],
             "count": round(ph_results.recent_launch_ratio * 100),
             "detail": f"{ph_results.recent_launch_ratio:.0%} of launches in last 6 months",
+        })
+    if so_results is not None and so_results.recent_question_ratio is not None:
+        evidence.append({
+            "source": "stackoverflow",
+            "type": "recent_question_ratio",
+            "query": keywords[0],
+            "count": round(so_results.recent_question_ratio * 100),
+            "detail": f"{so_results.recent_question_ratio:.0%} of questions in last 3 months",
         })
 
     # Add queried_at timestamp to all evidence items for credibility
@@ -753,6 +791,15 @@ def compute_signal(
                 "updated": prod.get("created_at", ""),
                 "description": prod.get("tagline", ""),
             })
+    if so_results:
+        for question in so_results.top_questions[:3]:
+            top_similars.append({
+                "name": f"so:{question['title'][:80]}",
+                "url": question["link"],
+                "stars": question.get("score", 0),
+                "updated": "",
+                "description": f"Stack Overflow — {question['answer_count']} answers, {'answered' if question['is_answered'] else 'unanswered'}",
+            })
 
     # Filter similars for relevance — prevent broad keyword matches
     top_similars = _filter_relevant_similars(top_similars, idea_text, keywords)
@@ -767,6 +814,7 @@ def compute_signal(
             "ecosystem_depth_npm": n_score if depth != "quick" else None,
             "ecosystem_depth_pypi": p_score if depth != "quick" else None,
             "product_launches": ph_val if depth != "quick" else None,
+            "developer_interest": so_val if depth != "quick" else None,
             "market_momentum": round(market_momentum * 100),
         },
         "trend": trend,

--- a/src/idea_reality_mcp/sources/stackoverflow.py
+++ b/src/idea_reality_mcp/sources/stackoverflow.py
@@ -1,0 +1,138 @@
+"""Stack Overflow API source."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+SO_API = "https://api.stackexchange.com/2.3/search"
+
+
+@dataclass
+class StackOverflowResults:
+    """Aggregated Stack Overflow search results."""
+
+    total_count: int = 0
+    top_questions: list[dict] = field(default_factory=list)
+    evidence: list[dict] = field(default_factory=list)
+    recent_question_ratio: float | None = None
+
+
+def _api_key() -> str | None:
+    return os.environ.get("STACKEXCHANGE_KEY")
+
+
+def _compute_recent_ratio(items: list[dict], three_months_ago: int) -> float | None:
+    """Compute ratio of questions within last 3 months vs total items returned.
+
+    Returns None if items is empty or timestamps cannot be parsed.
+    """
+    if not items:
+        return None
+    try:
+        recent = sum(1 for item in items if item.get("creation_date", 0) >= three_months_ago)
+        return recent / len(items)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+
+
+async def search_stackoverflow(keywords: list[str]) -> StackOverflowResults:
+    """Search Stack Overflow for questions matching keyword variants.
+
+    Uses the Stack Exchange API v2.3.
+    Free tier: 300 requests/day without auth.
+    Set STACKEXCHANGE_KEY env var for 10,000 requests/day.
+
+    Args:
+        keywords: List of search query strings.
+
+    Returns:
+        Aggregated results with total question count, top questions, and evidence.
+    """
+    now = datetime.now(timezone.utc)
+    three_months_ago = int((now - timedelta(days=90)).timestamp())
+    key = _api_key()
+
+    max_count = 0
+    best_ratio: float | None = None
+    all_questions: list[dict] = []
+    seen_ids: set[int] = set()
+    evidence: list[dict] = []
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        for query in keywords:
+            params: dict = {
+                "order": "desc",
+                "sort": "relevance",
+                "intitle": query,
+                "site": "stackoverflow",
+                "pagesize": 10,
+                "filter": "!9_bDDxJY5",  # include question_id, title, link, score, answer_count, is_answered, creation_date, tags
+            }
+            if key:
+                params["key"] = key
+
+            try:
+                resp = await client.get(SO_API, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+
+                items = data.get("items", [])
+                # The SO API does not return a reliable total in search; use quota_remaining
+                # and items count. We use len(items) + has_more as a lower-bound indicator,
+                # but treat total as the max items count seen (consistent with HN pattern).
+                count = len(items)
+                if data.get("has_more"):
+                    # Bump count to signal there are more results beyond pagesize
+                    count = count + 1
+
+                ratio = _compute_recent_ratio(items, three_months_ago)
+
+                if count > max_count:
+                    max_count = count
+                    best_ratio = ratio
+
+                # Collect unique questions (dedup by question_id)
+                for item in items:
+                    qid = item.get("question_id")
+                    if qid and qid not in seen_ids:
+                        seen_ids.add(qid)
+                        all_questions.append({
+                            "title": item.get("title", ""),
+                            "link": item.get("link", ""),
+                            "score": item.get("score", 0),
+                            "answer_count": item.get("answer_count", 0),
+                            "is_answered": item.get("is_answered", False),
+                            "creation_date": item.get("creation_date", 0),
+                            "tags": item.get("tags", []),
+                        })
+
+                evidence.append({
+                    "source": "stackoverflow",
+                    "type": "question_count",
+                    "query": query,
+                    "count": count,
+                    "detail": f"{count} Stack Overflow questions found for '{query}'",
+                })
+            except httpx.HTTPError:
+                evidence.append({
+                    "source": "stackoverflow",
+                    "type": "error",
+                    "query": query,
+                    "count": 0,
+                    "detail": f"Failed to query Stack Overflow for '{query}'",
+                })
+
+    # Sort by score descending and keep top 5
+    all_questions.sort(key=lambda q: q["score"], reverse=True)
+    top_questions = all_questions[:5]
+
+    return StackOverflowResults(
+        total_count=max_count,
+        top_questions=top_questions,
+        evidence=evidence,
+        recent_question_ratio=best_ratio,
+    )

--- a/src/idea_reality_mcp/tools.py
+++ b/src/idea_reality_mcp/tools.py
@@ -11,6 +11,7 @@ from .sources.hn import search_hn
 from .sources.npm import search_npm
 from .sources.pypi import search_pypi
 from .sources.producthunt import search_producthunt
+from .sources.stackoverflow import search_stackoverflow
 from .scoring.engine import compute_signal, extract_keywords
 
 
@@ -48,10 +49,11 @@ async def idea_check(
         npm_task = search_npm(keywords)
         pypi_task = search_pypi(keywords)
         ph_task = search_producthunt(keywords)
+        so_task = search_stackoverflow(keywords)
 
-        github_results, hn_results, npm_results, pypi_results, ph_results = (
+        github_results, hn_results, npm_results, pypi_results, ph_results, so_results = (
             await asyncio.gather(
-                github_task, hn_task, npm_task, pypi_task, ph_task,
+                github_task, hn_task, npm_task, pypi_task, ph_task, so_task,
             )
         )
 
@@ -64,6 +66,7 @@ async def idea_check(
             npm_results=npm_results,
             pypi_results=pypi_results,
             ph_results=ph_results,
+            so_results=so_results,
         )
     else:
         # Quick mode: GitHub + HN in parallel

--- a/tests/test_stackoverflow.py
+++ b/tests/test_stackoverflow.py
@@ -1,0 +1,313 @@
+"""Tests for Stack Overflow source adapter."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from idea_reality_mcp.sources.stackoverflow import StackOverflowResults, search_stackoverflow
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    """Create a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(),
+            response=resp,
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _so_item(
+    question_id: int,
+    title: str = "How to implement X?",
+    link: str = "https://stackoverflow.com/questions/1/how-to-implement-x",
+    score: int = 10,
+    answer_count: int = 3,
+    is_answered: bool = True,
+    creation_date: int = 1700000000,
+    tags: list[str] | None = None,
+) -> dict:
+    return {
+        "question_id": question_id,
+        "title": title,
+        "link": link,
+        "score": score,
+        "answer_count": answer_count,
+        "is_answered": is_answered,
+        "creation_date": creation_date,
+        "tags": tags or ["python", "api"],
+    }
+
+
+SAMPLE_ITEMS = [
+    _so_item(1, title="How to build a CLI in Python?", score=42, answer_count=5),
+    _so_item(2, title="Python CLI argument parsing best practices", score=27, answer_count=3),
+    _so_item(3, title="Comparing Python CLI frameworks", score=15, answer_count=2),
+]
+
+SAMPLE_RESPONSE = {
+    "items": SAMPLE_ITEMS,
+    "has_more": False,
+    "quota_remaining": 298,
+}
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestSearchStackOverflowSuccess:
+    @pytest.mark.asyncio
+    async def test_basic_success(self):
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(SAMPLE_RESPONSE)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["python cli"])
+
+        assert isinstance(result, StackOverflowResults)
+        assert result.total_count == 3
+        assert len(result.top_questions) == 3
+        assert result.top_questions[0]["title"] == "How to build a CLI in Python?"
+        assert result.top_questions[0]["score"] == 42
+        assert len(result.evidence) == 1
+        assert result.evidence[0]["source"] == "stackoverflow"
+        assert result.evidence[0]["type"] == "question_count"
+        assert result.evidence[0]["count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_has_more_bumps_count(self):
+        """When has_more is True, total_count should be pagesize + 1."""
+        response_with_more = {
+            "items": SAMPLE_ITEMS,
+            "has_more": True,
+            "quota_remaining": 290,
+        }
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(response_with_more)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["python cli"])
+
+        assert result.total_count == 4  # 3 items + 1 for has_more
+
+    @pytest.mark.asyncio
+    async def test_top_questions_sorted_by_score(self):
+        """top_questions must be sorted by score descending."""
+        items = [
+            _so_item(10, score=5),
+            _so_item(11, score=99),
+            _so_item(12, score=30),
+        ]
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response({"items": items, "has_more": False})
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["test"])
+
+        scores = [q["score"] for q in result.top_questions]
+        assert scores == sorted(scores, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_api_key_passed_when_env_set(self):
+        """STACKEXCHANGE_KEY env var should be included in request params."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(SAMPLE_RESPONSE)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            with patch.dict("os.environ", {"STACKEXCHANGE_KEY": "test-api-key"}):
+                await search_stackoverflow(["python cli"])
+
+        call_kwargs = mock_client.get.call_args
+        params = call_kwargs.kwargs.get("params", call_kwargs.args[1] if len(call_kwargs.args) > 1 else {})
+        assert params.get("key") == "test-api-key"
+
+    @pytest.mark.asyncio
+    async def test_no_api_key_when_env_not_set(self):
+        """Without STACKEXCHANGE_KEY, key param must not be sent."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(SAMPLE_RESPONSE)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        import os
+        env = {k: v for k, v in os.environ.items() if k != "STACKEXCHANGE_KEY"}
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            with patch.dict("os.environ", env, clear=True):
+                await search_stackoverflow(["python cli"])
+
+        call_kwargs = mock_client.get.call_args
+        params = call_kwargs.kwargs.get("params", {})
+        assert "key" not in params
+
+
+class TestSearchStackOverflowEmpty:
+    @pytest.mark.asyncio
+    async def test_empty_results(self):
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response({"items": [], "has_more": False})
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["very obscure topic xyz123"])
+
+        assert isinstance(result, StackOverflowResults)
+        assert result.total_count == 0
+        assert result.top_questions == []
+        assert result.recent_question_ratio is None
+        assert len(result.evidence) == 1
+        assert result.evidence[0]["count"] == 0
+
+
+class TestSearchStackOverflowApiError:
+    @pytest.mark.asyncio
+    async def test_http_error(self):
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response({}, status_code=500)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["broken query"])
+
+        assert isinstance(result, StackOverflowResults)
+        assert result.total_count == 0
+        assert result.top_questions == []
+        assert len(result.evidence) == 1
+        assert result.evidence[0]["type"] == "error"
+        assert "Failed" in result.evidence[0]["detail"]
+
+    @pytest.mark.asyncio
+    async def test_returns_results_from_successful_queries_when_one_fails(self):
+        """If second keyword fails, results from first keyword are preserved."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = [
+            _mock_response(SAMPLE_RESPONSE),
+            _mock_response({}, status_code=429),
+        ]
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["kw1", "kw2"])
+
+        assert result.total_count == 3  # from first successful query
+        assert len(result.top_questions) == 3
+        assert len(result.evidence) == 2
+        assert result.evidence[0]["type"] == "question_count"
+        assert result.evidence[1]["type"] == "error"
+
+
+class TestSearchStackOverflowMultipleKeywords:
+    @pytest.mark.asyncio
+    async def test_dedup_by_question_id(self):
+        """Same question_id appearing in multiple keyword queries must be deduplicated."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        # Both keywords return overlapping question_ids 1 and 2, plus unique ones
+        items_kw1 = [
+            _so_item(1, title="Shared question A", score=50),
+            _so_item(2, title="Shared question B", score=30),
+            _so_item(3, title="Unique to kw1", score=10),
+        ]
+        items_kw2 = [
+            _so_item(1, title="Shared question A", score=50),  # duplicate
+            _so_item(2, title="Shared question B", score=30),  # duplicate
+            _so_item(4, title="Unique to kw2", score=20),
+        ]
+        mock_client.get.side_effect = [
+            _mock_response({"items": items_kw1, "has_more": False}),
+            _mock_response({"items": items_kw2, "has_more": False}),
+        ]
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["kw1", "kw2"])
+
+        question_ids_in_result = {
+            q["title"] for q in result.top_questions
+        }
+        # All 4 unique questions should be present, not 6
+        assert len(result.top_questions) == 4
+        assert "Shared question A" in question_ids_in_result
+        assert "Shared question B" in question_ids_in_result
+        assert "Unique to kw1" in question_ids_in_result
+        assert "Unique to kw2" in question_ids_in_result
+
+    @pytest.mark.asyncio
+    async def test_max_count_across_keywords(self):
+        """total_count should be the max across queries, not the sum."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = [
+            _mock_response({"items": [_so_item(1)], "has_more": False}),
+            _mock_response({"items": [_so_item(2), _so_item(3)], "has_more": False}),
+        ]
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["kw1", "kw2"])
+
+        assert result.total_count == 2  # max(1, 2), not 3
+
+    @pytest.mark.asyncio
+    async def test_top_questions_capped_at_five(self):
+        """top_questions should contain at most 5 items."""
+        items = [_so_item(i, score=100 - i) for i in range(1, 9)]
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response({"items": items, "has_more": False})
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["broad topic"])
+
+        assert len(result.top_questions) == 5
+
+    @pytest.mark.asyncio
+    async def test_recent_question_ratio_computed(self):
+        """recent_question_ratio should reflect portion of recent questions."""
+        import time
+        now_ts = int(time.time())
+        recent_ts = now_ts - (30 * 24 * 3600)   # 30 days ago — within 3 months
+        old_ts = now_ts - (200 * 24 * 3600)     # 200 days ago — outside 3 months
+
+        items = [
+            _so_item(1, creation_date=recent_ts),
+            _so_item(2, creation_date=recent_ts),
+            _so_item(3, creation_date=old_ts),
+            _so_item(4, creation_date=old_ts),
+        ]
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response({"items": items, "has_more": False})
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("idea_reality_mcp.sources.stackoverflow.httpx.AsyncClient", return_value=mock_client):
+            result = await search_stackoverflow(["some topic"])
+
+        assert result.recent_question_ratio == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

Adds **Stack Overflow** as a 6th data source for deep mode searches, using the Stack Exchange API v2.3.

- New source: `sources/stackoverflow.py` — searches SO questions by keyword, returns total count, top questions (sorted by score), and recent question ratio
- Scoring integration: `developer_interest` sub-score with log-curve calibration (`k ≈ 17.91`)
- Deep mode weights redistributed proportionally (all existing weights × 0.9, SO gets 0.10)
- Weight redistribution when SO unavailable follows the same pattern as Product Hunt
- Temporal boost: `recent_question_ratio` (questions in last 3 months) feeds into `market_momentum`
- Optional `STACKEXCHANGE_KEY` env var for higher rate limits (300/day free → 10,000/day with key)

## Why Stack Overflow?

Stack Overflow questions are a strong signal for **developer interest and ecosystem maturity**:
- High question count → established problem space with active community
- Recent questions → growing developer adoption
- Accepted answers → mature solutions already exist

This complements the existing sources: GitHub (code), HN (discussion), npm/PyPI (packages), Product Hunt (products), and now SO (developer Q&A).

## Changes

| File | Change |
|------|--------|
| `sources/stackoverflow.py` | New async source following existing patterns |
| `scoring/engine.py` | Import, `_so_score()`, weight redistribution, evidence, temporal ratio |
| `tools.py` | Added to `asyncio.gather` in deep mode |
| `tests/test_stackoverflow.py` | 12 tests: success, empty, error, dedup, has_more, API key, sorting, cap, recent ratio |

## Deep mode weight redistribution

| Source | Before | After |
|--------|--------|-------|
| GitHub repos | 0.25 | 0.22 |
| GitHub stars | 0.10 | 0.09 |
| HN | 0.15 | 0.14 |
| npm | 0.20 | 0.18 |
| PyPI | 0.15 | 0.13 |
| Product Hunt | 0.15 | 0.14 |
| **Stack Overflow** | — | **0.10** |

## Test plan

- [x] All 12 new Stack Overflow tests pass
- [x] All 110 existing tests pass (zero regressions)
- [x] `uv run pytest` — full suite green
- [ ] Manual test with `uvx` (requires live API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>