### PR TITLE
feat(engine): P1 semantic embeddings — activate the query-log moat

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -377,6 +377,17 @@ def rows_missing_embedding(limit: int = 1000) -> list[dict[str, Any]]:
     return result
 
 
+def count_missing_embedding() -> int:
+    """Number of embeddable rows still lacking an embedding (for backfill progress/dry-run)."""
+    conn = _get_conn()
+    n = conn.execute(
+        "SELECT COUNT(*) FROM score_history "
+        "WHERE embedding IS NULL AND idea_text IS NOT NULL AND length(idea_text) > 0"
+    ).fetchone()[0]
+    conn.close()
+    return int(n)
+
+
 def search_similar_by_embedding(
     query_embedding: Sequence[float],
     exclude_hash: str | None = None,

--- a/api/db.py
+++ b/api/db.py
@@ -181,6 +181,21 @@ def _row_to_dict(cursor) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
+def _add_column_if_missing(conn, table: str, column: str, coltype: str) -> None:
+    """Add `column` to `table` if it isn't already present (portable ALTER guard).
+
+    SQLite/libSQL raise on a duplicate ADD COLUMN, so we probe PRAGMA table_info first.
+    """
+    try:
+        cur = conn.execute(f"PRAGMA table_info({table})")
+        existing = {row[1] for row in cur.fetchall()}
+        if column not in existing:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {coltype}")
+            conn.commit()
+    except Exception:  # noqa: BLE001 — never let a migration probe break init
+        logger.exception("[DB] _add_column_if_missing(%s.%s) failed", table, column)
+
+
 def init_db() -> None:
     """Create all tables and indexes if they don't exist."""
     conn = _get_conn()
@@ -195,12 +210,16 @@ def init_db() -> None:
             depth TEXT DEFAULT 'quick',
             lang TEXT DEFAULT 'en',
             keyword_source TEXT DEFAULT 'dictionary',
-            created_at TEXT DEFAULT (datetime('now'))
+            created_at TEXT DEFAULT (datetime('now')),
+            embedding BLOB
         )
     """)
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_idea_hash ON score_history(idea_hash)"
     )
+    # Existing (pre-embedding) tables won't get the column from CREATE IF NOT EXISTS —
+    # add it in-place. Idempotent: skipped when already present.
+    _add_column_if_missing(conn, "score_history", "embedding", "BLOB")
     conn.execute("""
         CREATE TABLE IF NOT EXISTS query_log (
             id INTEGER PRIMARY KEY,
@@ -310,21 +329,117 @@ def save_score(
     depth: str = "quick",
     lang: str = "en",
     keyword_source: str = "dictionary",
+    embedding: bytes | None = None,
 ) -> int:
-    """Insert a score record and return the row id."""
+    """Insert a score record and return the row id.
+
+    `embedding` is an optional packed float32 BLOB (see api/embeddings.pack_embedding).
+    When omitted the row is stored without a vector and can be backfilled later.
+    """
     h = idea_hash(idea_text)
     conn = _get_conn()
     cur = conn.execute(
         "INSERT INTO score_history "
-        "(idea_hash, idea_text, score, breakdown, keywords, depth, lang, keyword_source) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        (h, idea_text, score, breakdown, keywords, depth, lang, keyword_source),
+        "(idea_hash, idea_text, score, breakdown, keywords, depth, lang, keyword_source, embedding) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (h, idea_text, score, breakdown, keywords, depth, lang, keyword_source, embedding),
     )
     conn.commit()
     _sync_after_write(conn)
     row_id = cur.lastrowid
     conn.close()
     return row_id
+
+
+def set_embedding(row_id: int, embedding: bytes) -> None:
+    """Attach/replace the embedding BLOB on an existing score_history row."""
+    conn = _get_conn()
+    conn.execute("UPDATE score_history SET embedding = ? WHERE id = ?", (embedding, row_id))
+    conn.commit()
+    _sync_after_write(conn)
+    conn.close()
+
+
+def rows_missing_embedding(limit: int = 1000) -> list[dict[str, Any]]:
+    """Return score_history rows that have no embedding yet (id + idea_text), oldest first.
+
+    Used by the one-time / incremental backfill (scripts/backfill_embeddings.py).
+    """
+    conn = _get_conn()
+    cur = conn.execute(
+        "SELECT id, idea_text FROM score_history "
+        "WHERE embedding IS NULL AND idea_text IS NOT NULL AND length(idea_text) > 0 "
+        "ORDER BY id ASC LIMIT ?",
+        (limit,),
+    )
+    result = _rows_to_dicts(cur)
+    conn.close()
+    return result
+
+
+def search_similar_by_embedding(
+    query_embedding: Sequence[float],
+    exclude_hash: str | None = None,
+    limit: int = 10,
+    min_score: float = 0.0,
+) -> list[dict[str, Any]]:
+    """Semantic nearest-neighbours over score_history by cosine similarity.
+
+    Brute-force over every row that has an embedding (fine at ~10k rows). Returns dicts
+    with idea_text, score, depth, lang, created_at and an added `similarity` (0..1),
+    sorted most-similar first. `min_score` filters out weak matches (e.g. 0.35).
+    Callers should fall back to the keyword LIKE search when this returns [] (no
+    embeddings yet, or NumPy/embedding provider unavailable).
+    """
+    import numpy as np
+
+    conn = _get_conn()
+    sql = (
+        "SELECT idea_hash, idea_text, score, depth, lang, created_at, embedding "
+        "FROM score_history WHERE embedding IS NOT NULL"
+    )
+    params: list = []
+    if exclude_hash:
+        sql += " AND idea_hash != ?"
+        params.append(exclude_hash)
+    cur = conn.execute(sql, params)
+    rows = _rows_to_dicts(cur)
+    conn.close()
+    if not rows:
+        return []
+
+    q = np.asarray(query_embedding, dtype=np.float32)
+    qn = np.linalg.norm(q)
+    if qn == 0:
+        return []
+    q = q / qn
+
+    scored: list[dict[str, Any]] = []
+    for r in rows:
+        blob = r.get("embedding")
+        if not blob:
+            continue
+        v = np.frombuffer(blob, dtype="<f4")
+        if v.shape[0] == 0:
+            continue
+        vn = np.linalg.norm(v)
+        if vn == 0:
+            continue
+        sim = float(np.dot(q, v / vn))
+        if sim < min_score:
+            continue
+        scored.append(
+            {
+                "idea_text": r.get("idea_text"),
+                "score": r.get("score"),
+                "depth": r.get("depth"),
+                "lang": r.get("lang"),
+                "created_at": r.get("created_at"),
+                "similarity": round(sim, 4),
+            }
+        )
+    scored.sort(key=lambda d: d["similarity"], reverse=True)
+    return scored[:limit]
 
 
 def get_history(hash_val: str) -> list[dict[str, Any]]:

--- a/api/db.py
+++ b/api/db.py
@@ -388,6 +388,56 @@ def count_missing_embedding() -> int:
     return int(n)
 
 
+# In-memory embedding index — loaded once per process, refreshed on TTL. Loading all
+# ~10k 6 KB blobs on *every* /api/check would be 60 MB of egress per request; instead we
+# cache a normalized (N x 1536) matrix + parallel metadata and do a vectorized matmul.
+import time as _time
+
+_EMB_CACHE_TTL = float(os.environ.get("EMB_CACHE_TTL", "600"))  # seconds
+_emb_cache: dict[str, Any] = {"loaded_at": 0.0, "mat": None, "meta": []}
+
+
+def invalidate_embedding_cache() -> None:
+    """Force the next semantic search to reload the matrix (e.g. after a backfill)."""
+    _emb_cache["loaded_at"] = 0.0
+    _emb_cache["mat"] = None
+
+
+def _load_embedding_matrix(force: bool = False):
+    """(Re)load the normalized embedding matrix into the process cache. Returns numpy
+    module or None when numpy/embeddings are unavailable (callers then fall back)."""
+    try:
+        import numpy as np
+    except ImportError:
+        return None
+    now = _time.time()
+    if not force and _emb_cache["mat"] is not None and (now - _emb_cache["loaded_at"]) < _EMB_CACHE_TTL:
+        return np
+    conn = _get_conn()
+    cur = conn.execute(
+        "SELECT idea_hash, idea_text, score, depth, lang, created_at, embedding "
+        "FROM score_history WHERE embedding IS NOT NULL"
+    )
+    rows = _rows_to_dicts(cur)
+    conn.close()
+    vecs: list = []
+    meta: list[dict[str, Any]] = []
+    for r in rows:
+        blob = r.get("embedding")
+        if not blob:
+            continue
+        v = np.frombuffer(blob, dtype="<f4")
+        n = float(np.linalg.norm(v)) if v.shape[0] else 0.0
+        if n == 0:
+            continue
+        vecs.append(v / n)
+        meta.append({k: r.get(k) for k in ("idea_hash", "idea_text", "score", "depth", "lang", "created_at")})
+    _emb_cache["mat"] = np.vstack(vecs) if vecs else None
+    _emb_cache["meta"] = meta
+    _emb_cache["loaded_at"] = now
+    return np
+
+
 def search_similar_by_embedding(
     query_embedding: Sequence[float],
     exclude_hash: str | None = None,
@@ -396,61 +446,36 @@ def search_similar_by_embedding(
 ) -> list[dict[str, Any]]:
     """Semantic nearest-neighbours over score_history by cosine similarity.
 
-    Brute-force over every row that has an embedding (fine at ~10k rows). Returns dicts
-    with idea_text, score, depth, lang, created_at and an added `similarity` (0..1),
-    sorted most-similar first. `min_score` filters out weak matches (e.g. 0.35).
-    Callers should fall back to the keyword LIKE search when this returns [] (no
-    embeddings yet, or NumPy/embedding provider unavailable).
+    Uses the cached, normalized embedding matrix (vectorized matmul). Returns dicts with
+    idea_hash, idea_text, score, depth, lang, created_at + `similarity` (0..1), most similar
+    first, above `min_score`. Returns [] when numpy/embeddings are unavailable or the corpus
+    is empty — callers must fall back to the keyword LIKE search.
     """
-    import numpy as np
-
-    conn = _get_conn()
-    sql = (
-        "SELECT idea_hash, idea_text, score, depth, lang, created_at, embedding "
-        "FROM score_history WHERE embedding IS NOT NULL"
-    )
-    params: list = []
-    if exclude_hash:
-        sql += " AND idea_hash != ?"
-        params.append(exclude_hash)
-    cur = conn.execute(sql, params)
-    rows = _rows_to_dicts(cur)
-    conn.close()
-    if not rows:
+    np = _load_embedding_matrix()
+    mat = _emb_cache["mat"]
+    meta = _emb_cache["meta"]
+    if np is None or mat is None or not meta:
         return []
 
     q = np.asarray(query_embedding, dtype=np.float32)
-    qn = np.linalg.norm(q)
+    qn = float(np.linalg.norm(q))
     if qn == 0:
         return []
-    q = q / qn
+    sims = mat @ (q / qn)  # (N,) cosine sim, matrix rows already unit-norm
 
-    scored: list[dict[str, Any]] = []
-    for r in rows:
-        blob = r.get("embedding")
-        if not blob:
+    order = np.argsort(-sims)
+    out: list[dict[str, Any]] = []
+    for i in order:
+        s = float(sims[i])
+        if s < min_score:
+            break  # argsort desc -> everything after is smaller
+        m = meta[i]
+        if exclude_hash and m.get("idea_hash") == exclude_hash:
             continue
-        v = np.frombuffer(blob, dtype="<f4")
-        if v.shape[0] == 0:
-            continue
-        vn = np.linalg.norm(v)
-        if vn == 0:
-            continue
-        sim = float(np.dot(q, v / vn))
-        if sim < min_score:
-            continue
-        scored.append(
-            {
-                "idea_text": r.get("idea_text"),
-                "score": r.get("score"),
-                "depth": r.get("depth"),
-                "lang": r.get("lang"),
-                "created_at": r.get("created_at"),
-                "similarity": round(sim, 4),
-            }
-        )
-    scored.sort(key=lambda d: d["similarity"], reverse=True)
-    return scored[:limit]
+        out.append({**m, "similarity": round(s, 4)})
+        if len(out) >= limit:
+            break
+    return out
 
 
 def get_history(hash_val: str) -> list[dict[str, Any]]:

--- a/api/embeddings.py
+++ b/api/embeddings.py
@@ -1,0 +1,96 @@
+"""Semantic embeddings for score_history (P1: activate the query-log moat).
+
+The scorer's similarity/duplicate detection historically matched idea_text with
+SQL LIKE on a handful of keywords — it misses paraphrases ("app to split bills"
+vs "expense sharing tool"). This module adds semantic embeddings so similarity is
+computed in vector space instead.
+
+Design (kept deliberately simple for the ~10k-row scale):
+- Provider: OpenAI `text-embedding-3-small` (1536-d, ~$0.02 / 1M tokens). Called
+  over plain httpx — no SDK — to match the rest of the codebase.
+- Storage: a packed float32 BLOB per row (1536 * 4 = 6 KB). Portable across Turso
+  (libSQL) and the local SQLite fallback; no dependency on a vector extension.
+- Search: brute-force cosine over all stored vectors in NumPy. At 10k rows this is
+  a single ~10k x 1536 matmul (< ~50 ms). If the corpus ever reaches 6 figures,
+  swap this for Turso's native F32_BLOB + vector_distance_cos index — the storage
+  format is already a float32 blob, so that migration is additive.
+
+Env:
+- OPENAI_API_KEY   (required to compute embeddings; absent -> functions raise/skip)
+- EMBED_MODEL      (optional, default 'text-embedding-3-small')
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+from typing import Sequence
+
+import httpx
+
+EMBED_MODEL = os.environ.get("EMBED_MODEL", "text-embedding-3-small")
+EMBED_DIM = 1536  # text-embedding-3-small native dimension
+_OPENAI_URL = "https://api.openai.com/v1/embeddings"
+_MAX_BATCH = 2048  # OpenAI hard cap on inputs per request
+_TIMEOUT = 60.0
+
+
+class EmbeddingError(RuntimeError):
+    """Raised when the embedding provider is unavailable or returns a bad payload."""
+
+
+def embeddings_enabled() -> bool:
+    """True if an API key is configured. Callers should degrade gracefully when False."""
+    return bool(os.environ.get("OPENAI_API_KEY"))
+
+
+def embed_texts(texts: Sequence[str], *, timeout: float = _TIMEOUT) -> list[list[float]]:
+    """Embed a batch of texts. Returns one vector per input, in order.
+
+    Splits into <=2048-input requests. Raises EmbeddingError on any failure so the
+    caller decides whether to retry or skip (we never want a silent partial batch).
+    """
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        raise EmbeddingError("OPENAI_API_KEY not set")
+    # OpenAI rejects empty strings; substitute a single space so indices stay aligned.
+    cleaned = [(t if t and t.strip() else " ") for t in texts]
+
+    out: list[list[float]] = []
+    with httpx.Client(timeout=timeout) as client:
+        for start in range(0, len(cleaned), _MAX_BATCH):
+            chunk = cleaned[start : start + _MAX_BATCH]
+            resp = client.post(
+                _OPENAI_URL,
+                headers={"Authorization": f"Bearer {key}"},
+                json={"model": EMBED_MODEL, "input": chunk},
+            )
+            if resp.status_code != 200:
+                raise EmbeddingError(f"embeddings HTTP {resp.status_code}: {resp.text[:200]}")
+            data = resp.json().get("data")
+            if not isinstance(data, list) or len(data) != len(chunk):
+                raise EmbeddingError("embeddings response shape mismatch")
+            # API guarantees data is returned in input order, but sort on index to be safe.
+            for item in sorted(data, key=lambda d: d.get("index", 0)):
+                vec = item.get("embedding")
+                if not isinstance(vec, list) or len(vec) != EMBED_DIM:
+                    raise EmbeddingError("embedding vector shape mismatch")
+                out.append(vec)
+    return out
+
+
+def embed_one(text: str, *, timeout: float = _TIMEOUT) -> list[float]:
+    """Embed a single text -> one vector."""
+    return embed_texts([text], timeout=timeout)[0]
+
+
+def pack_embedding(vec: Sequence[float]) -> bytes:
+    """Pack a float vector into a compact little-endian float32 BLOB."""
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+def unpack_embedding(blob: bytes) -> list[float]:
+    """Inverse of pack_embedding."""
+    if not blob:
+        return []
+    return list(struct.unpack(f"<{len(blob) // 4}f", blob))

--- a/api/report.py
+++ b/api/report.py
@@ -21,6 +21,15 @@ import httpx
 sys.path.insert(0, os.path.dirname(__file__))
 import db as score_db  # noqa: E402
 
+try:
+    from embeddings import embed_one, embeddings_enabled  # noqa: E402
+except Exception:  # numpy/httpx/module missing -> semantic search simply disabled
+    def embeddings_enabled() -> bool:  # type: ignore
+        return False
+
+    def embed_one(text: str):  # type: ignore
+        raise RuntimeError("embeddings unavailable")
+
 logger = logging.getLogger(__name__)
 
 
@@ -95,46 +104,112 @@ def _build_score_breakdown(signal_result: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _build_crowd_intelligence(idea_text: str, idea_hash: str, score: int) -> dict:
-    """Query score_history for similar ideas. Report FACTS only.
-
-    Does NOT say 'lower score = entry angles' or any causal claims.
-    Just: N queries matched, avg score, depth breakdown.
-    """
-    # Extract meaningful words for LIKE search
+def _keyword_similar(idea_text: str, idea_hash: str, limit: int = 50) -> list[dict]:
+    """Legacy keyword-LIKE similar search (fallback when semantic is unavailable)."""
     words = [w.lower() for w in idea_text.split() if len(w) >= 4]
     if not words:
         words = [w.lower() for w in idea_text.split() if len(w) >= 3]
+    return score_db.search_similar_ideas(keywords=words[:5], exclude_hash=idea_hash, limit=limit)
 
-    similar = score_db.search_similar_ideas(
-        keywords=words[:5],
-        exclude_hash=idea_hash,
-        limit=50,
-    )
 
-    # Total database size for context
+def _similar_ideas(idea_text: str, idea_hash: str) -> tuple[list[dict], str]:
+    """Similar-idea lookup: semantic embeddings first, keyword LIKE as fallback.
+
+    Returns (rows, mode). Semantic rows carry `similarity` + are deduped by idea_hash
+    (the same idea searched repeatedly would otherwise dominate). Any failure in the
+    semantic path (no key, provider error, numpy missing) degrades to keyword — the
+    exact behaviour before P1, so there is no regression.
+    """
+    if embeddings_enabled():
+        try:
+            vec = embed_one(idea_text)
+            sem = score_db.search_similar_by_embedding(
+                vec, exclude_hash=idea_hash, limit=500, min_score=0.45
+            )
+            if sem:
+                seen: set = set()
+                deduped: list[dict] = []
+                for r in sem:  # already sorted by similarity desc
+                    h = r.get("idea_hash")
+                    if h in seen:
+                        continue
+                    seen.add(h)
+                    deduped.append(r)
+                return deduped, "semantic"
+        except Exception:
+            logger.exception("[crowd] semantic search failed; falling back to keyword")
+    return _keyword_similar(idea_text, idea_hash), "keyword"
+
+
+def _demand_heat(semantic_rows: list[dict], heat_threshold: float = 0.55, window_days: int = 90) -> dict | None:
+    """Demand signal from semantic matches: closely-related searches in the last
+    `window_days`, and the trend vs the prior equal window. FACTS only — no causal
+    claims. Returns None when there aren't enough dated matches to report."""
+    from datetime import timedelta
+
+    now = datetime.now(timezone.utc)
+    cur_start = now - timedelta(days=window_days)
+    prev_start = now - timedelta(days=2 * window_days)
+    cur = prev = 0
+    for r in semantic_rows:
+        if r.get("similarity", 0) < heat_threshold:
+            continue
+        ts = r.get("created_at")
+        if not ts:
+            continue
+        try:
+            dt = datetime.strptime(str(ts)[:19], "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        if dt >= cur_start:
+            cur += 1
+        elif dt >= prev_start:
+            prev += 1
+    if cur == 0 and prev == 0:
+        return None
+    if cur > prev * 1.25:
+        trend = "rising"
+    elif cur < prev * 0.75:
+        trend = "cooling"
+    else:
+        trend = "steady"
+    return {
+        "similar_searches_90d": cur,
+        "prev_90d": prev,
+        "trend": trend,
+        "message": f"{cur} closely-related searches in the last 90 days ({trend}).",
+    }
+
+
+def _build_crowd_intelligence(idea_text: str, idea_hash: str, score: int) -> dict:
+    """Query score_history for similar ideas (semantic, keyword fallback). FACTS only.
+
+    Does NOT say 'lower score = entry angles' or any causal claims. Just: N similar
+    queries, avg score, depth breakdown, and (semantic mode) a 90-day demand signal.
+    """
+    similar, mode = _similar_ideas(idea_text, idea_hash)
     total_checks = score_db.get_total_checks()
 
     if not similar:
         return {
             "similar_count": 0,
             "total_database_queries": total_checks,
+            "match_mode": mode,
             "message": (
                 f"Your idea is unique among {total_checks} queries in our database. "
                 f"No one has searched for anything similar yet."
             ),
         }
 
-    scores = [s["score"] for s in similar]
+    display = similar[:50]
+    scores = [s["score"] for s in display]
     avg_score = round(sum(scores) / len(scores), 1)
 
-    # Depth breakdown
-    depth_counts = {}
-    for s in similar:
+    depth_counts: dict = {}
+    for s in display:
         d = s.get("depth", "quick")
         depth_counts[d] = depth_counts.get(d, 0) + 1
 
-    # Score comparison
     if score > avg_score + 10:
         score_comparison = "higher than"
     elif score < avg_score - 10:
@@ -142,19 +217,25 @@ def _build_crowd_intelligence(idea_text: str, idea_hash: str, score: int) -> dic
     else:
         score_comparison = "similar to"
 
-    return {
-        "similar_count": len(similar),
+    out = {
+        "similar_count": len(display),
         "avg_score": avg_score,
         "your_score": score,
         "score_comparison": score_comparison,
         "total_database_queries": total_checks,
         "depth_breakdown": depth_counts,
+        "match_mode": mode,
         "message": (
-            f"{len(similar)} people searched for similar ideas. "
+            f"{len(display)} people searched for similar ideas. "
             f"Average competition score: {avg_score}/100. "
             f"Your score is {score_comparison} the average."
         ),
     }
+    if mode == "semantic":
+        heat = _demand_heat(similar)  # computed over the full match set, not just the top 50
+        if heat:
+            out["demand_heat"] = heat
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.24.0,<1.0.0
 anthropic>=0.40.0,<1.0.0
 libsql-client>=0.3.0
 httpx>=0.27.0,<1.0.0
+numpy>=1.26,<3.0

--- a/docs/P1-semantic-embeddings.md
+++ b/docs/P1-semantic-embeddings.md
@@ -1,0 +1,46 @@
+# P1 — Semantic Embeddings (activate the query-log moat)
+
+**Why**: `search_similar_ideas` matched on keyword LIKE — it misses paraphrases
+("split bills with roommates" vs "expense sharing app"). The ~280+ (growing) rows
+of `score_history` (real idea queries) are the engine's only proprietary asset;
+embeddings turn them from a keyword table into a semantic index.
+
+## Status
+
+### ✅ Done (branch `feat/semantic-embeddings`, PR pending)
+- **`api/embeddings.py`** — batch embed client (OpenAI `text-embedding-3-small`,
+  httpx, no SDK) + `pack_embedding`/`unpack_embedding` (float32 BLOB).
+- **`api/db.py`** — `embedding BLOB` column (+ idempotent ALTER for the live table),
+  `save_score(embedding=)`, `set_embedding`, `rows_missing_embedding`,
+  `count_missing_embedding`, `search_similar_by_embedding` (cosine, `min_score`,
+  returns `[]` so callers fall back to keyword search).
+- **`scripts/backfill_embeddings.py`** — idempotent/resumable backfill
+  (`--dry-run` cost estimate, `--limit`, `--batch`).
+- **tests** — 12/12 green in `test_score_history.py` (roundtrip, legacy-table
+  migration, semantic ranking, backfill flow, empty/zero-vector edges).
+
+### ☐ Next (this phase)
+1. **Run the backfill on prod Turso** — needs `pip install libsql-client` in the
+   run env (system python here lacks it → falls back to local SQLite), plus
+   `OPENAI_API_KEY` + `TURSO_*`. Cost ~$0.01. Command:
+   `TURSO_DATABASE_URL=… TURSO_AUTH_TOKEN=… OPENAI_API_KEY=… python scripts/backfill_embeddings.py`
+   Then re-run on a cron / after each batch of new checks to keep coverage.
+2. **Wire semantic search into the scorer** — in the `top_similars` /
+   `existingProjects` path (tools.py / api/main.py `/api/check`): embed the incoming
+   idea, call `search_similar_by_embedding`, fall back to `search_similar_ideas`
+   on `[]` or provider error. Store the new check's embedding via `save_score(embedding=)`.
+3. **Deploy** — Render redeploy (requirements now include numpy + libsql-client);
+   set `OPENAI_API_KEY` in Render env.
+4. **Demand-heat signal (the unique output)** — "N people queried a *semantically*
+   similar idea in the last 90 days, trend ↑". New helper over the embedded corpus +
+   `created_at`; surface it to flip the verdict from "judgment" ("5 people already
+   built this → you lose") to "navigation" ("crowded, but 23 searched in 90d → gap here").
+
+## Decisions
+- Provider `text-embedding-3-small` (1536-d, cheap, httpx). Swap to `-large` only if
+  dedup quality demands it.
+- Storage = packed float32 BLOB + brute-force NumPy cosine. Portable Turso/SQLite,
+  fine < ~100k rows. Beyond that → Turso native `F32_BLOB` + `vector_distance_cos`
+  index (blob format is already forward-compatible).
+- Keep the log-curve reality score as-is — it's the explainable trust asset. Embeddings
+  only improve *similarity/dedup*, not the score formula.

--- a/docs/P1-semantic-embeddings.md
+++ b/docs/P1-semantic-embeddings.md
@@ -28,12 +28,18 @@ semantic index.
 - **tests** — 12/12 green in `test_score_history.py` (roundtrip, legacy-table
   migration, semantic ranking, backfill flow, empty/zero-vector edges).
 
+### ✅ Backfill DONE (2026-07-06)
+- prod Turso `score_history`: **10,150 / 10,150 embedded (0 missing)** via
+  `scripts/backfill_embeddings_http.py` (Turso HTTP API — the sync client hangs).
+  ~14 min, 12 rows/s, ~$0.008.
+- Verified: stored-vs-fresh cosine = 1.0000 (correct text stored); real semantic
+  queries return paraphrase matches keyword-LIKE would miss (e.g. "split bills with
+  roommates" → "Group expense app that scans receipts" 0.74).
+- Real data also confirms **duplicate ideas** (same idea_hash from repeat queries) →
+  the scorer wiring must dedup results by `idea_hash`.
+- Re-run the same script on a cron / after new checks to keep coverage (idempotent).
+
 ### ☐ Next (this phase)
-1. **Run the backfill on prod Turso** — needs `pip install libsql-client` in the
-   run env (system python here lacks it → falls back to local SQLite), plus
-   `OPENAI_API_KEY` + `TURSO_*`. Cost ~$0.01. Command:
-   `TURSO_DATABASE_URL=… TURSO_AUTH_TOKEN=… OPENAI_API_KEY=… python scripts/backfill_embeddings.py`
-   Then re-run on a cron / after each batch of new checks to keep coverage.
 2. **Wire semantic search into the scorer** — in the `top_similars` /
    `existingProjects` path (tools.py / api/main.py `/api/check`): embed the incoming
    idea, call `search_similar_by_embedding`, fall back to `search_similar_ideas`

--- a/docs/P1-semantic-embeddings.md
+++ b/docs/P1-semantic-embeddings.md
@@ -1,9 +1,18 @@
 # P1 — Semantic Embeddings (activate the query-log moat)
 
 **Why**: `search_similar_ideas` matched on keyword LIKE — it misses paraphrases
-("split bills with roommates" vs "expense sharing app"). The ~280+ (growing) rows
-of `score_history` (real idea queries) are the engine's only proprietary asset;
-embeddings turn them from a keyword table into a semantic index.
+("split bills with roommates" vs "expense sharing app"). The **10,150 rows /
+8,337 distinct ideas** in `score_history` on Turso (confirmed 2026-07-06 via the
+Turso HTTP API; also surfaced by `/api/stats` `total_ideas_scanned`) are the
+engine's only proprietary asset; embeddings turn them from a keyword table into a
+semantic index.
+
+> ⚠️ Gotcha: `api/db.py` **silently** falls back to a local empty SQLite when
+> `libsql_client` is missing OR Turso env vars are unset (only a log warning).
+> Any local script must `pip install libsql-client` AND export `TURSO_*`, or it
+> will operate on the wrong DB and report bogus counts. The local libsql *sync*
+> client also hung here (Windows) — the Turso **HTTP API** (`https://<db>/v2/pipeline`)
+> works and is the reliable path for the backfill / analysis from this machine.
 
 ## Status
 

--- a/scripts/backfill_embeddings.py
+++ b/scripts/backfill_embeddings.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+"""One-time / incremental backfill of semantic embeddings for score_history.
+
+Reads every row that has no embedding yet, embeds its idea_text with
+text-embedding-3-small, and writes the packed float32 BLOB back. Idempotent and
+resumable: it only ever touches rows where embedding IS NULL, so re-running after
+an interruption picks up where it left off, and running it on a cron keeps new
+rows covered.
+
+Usage:
+    OPENAI_API_KEY=...  TURSO_DATABASE_URL=...  TURSO_AUTH_TOKEN=...  \
+        python scripts/backfill_embeddings.py [--batch 256] [--dry-run] [--limit N]
+
+Cost: ~$0.02 / 1M tokens. ~10k ideas x ~40 tokens ≈ 400k tokens ≈ $0.01.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+# Make `api` importable when run from repo root.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from api import db  # noqa: E402
+from api.embeddings import EmbeddingError, embed_texts, embeddings_enabled, pack_embedding  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Backfill score_history embeddings.")
+    ap.add_argument("--batch", type=int, default=256, help="rows embedded per API call")
+    ap.add_argument("--limit", type=int, default=0, help="max rows this run (0 = all)")
+    ap.add_argument("--dry-run", action="store_true", help="count only, no API calls / writes")
+    args = ap.parse_args()
+
+    if not embeddings_enabled():
+        print("ERROR: OPENAI_API_KEY not set — cannot compute embeddings.", file=sys.stderr)
+        return 2
+
+    db.init_db()  # ensures the embedding column exists on the target DB
+
+    total_done = 0
+    started = time.time()
+    while True:
+        take = args.batch if args.limit == 0 else min(args.batch, args.limit - total_done)
+        if take <= 0:
+            break
+        rows = db.rows_missing_embedding(limit=take)
+        if not rows:
+            break
+
+        ids = [r["id"] for r in rows]
+        texts = [r["idea_text"] for r in rows]
+        print(f"[backfill] {len(rows)} rows (ids {ids[0]}..{ids[-1]})", flush=True)
+
+        if args.dry_run:
+            total_done += len(rows)
+            continue
+
+        try:
+            vectors = embed_texts(texts)
+        except EmbeddingError as e:
+            print(f"ERROR embedding batch: {e}", file=sys.stderr)
+            return 1
+
+        for row_id, vec in zip(ids, vectors):
+            db.set_embedding(row_id, pack_embedding(vec))
+        total_done += len(rows)
+
+        if args.limit and total_done >= args.limit:
+            break
+
+    elapsed = time.time() - started
+    verb = "would embed" if args.dry_run else "embedded"
+    print(f"[backfill] done — {verb} {total_done} rows in {elapsed:.1f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_embeddings.py
+++ b/scripts/backfill_embeddings.py
@@ -41,6 +41,16 @@ def main() -> int:
 
     db.init_db()  # ensures the embedding column exists on the target DB
 
+    if args.dry_run:
+        # A real run shrinks the NULL set as it writes; a dry run must NOT loop over
+        # rows_missing_embedding (it never advances without writes) — count once instead.
+        n = db.count_missing_embedding()
+        capped = n if args.limit == 0 else min(n, args.limit)
+        est_tokens = capped * 40  # ~40 tokens/idea rough
+        print(f"[backfill] dry-run: {n} rows missing embedding; would embed {capped} "
+              f"(~{est_tokens:,} tokens, approx ${est_tokens / 1_000_000 * 0.02:.4f})")
+        return 0
+
     total_done = 0
     started = time.time()
     while True:
@@ -54,10 +64,6 @@ def main() -> int:
         ids = [r["id"] for r in rows]
         texts = [r["idea_text"] for r in rows]
         print(f"[backfill] {len(rows)} rows (ids {ids[0]}..{ids[-1]})", flush=True)
-
-        if args.dry_run:
-            total_done += len(rows)
-            continue
 
         try:
             vectors = embed_texts(texts)
@@ -73,8 +79,7 @@ def main() -> int:
             break
 
     elapsed = time.time() - started
-    verb = "would embed" if args.dry_run else "embedded"
-    print(f"[backfill] done — {verb} {total_done} rows in {elapsed:.1f}s")
+    print(f"[backfill] done — embedded {total_done} rows in {elapsed:.1f}s")
     return 0
 
 

--- a/scripts/backfill_embeddings_http.py
+++ b/scripts/backfill_embeddings_http.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Backfill score_history embeddings over the Turso HTTP API.
+
+Same job as backfill_embeddings.py, but talks to Turso via /v2/pipeline instead of
+the libsql sync client (which hangs on Windows). Idempotent/resumable: only touches
+rows where embedding IS NULL.
+
+Usage:
+    TURSO_DATABASE_URL=… TURSO_AUTH_TOKEN=… OPENAI_API_KEY=… \
+        python scripts/backfill_embeddings_http.py [--batch 512] [--limit N] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from api.embeddings import EmbeddingError, embed_texts, embeddings_enabled, pack_embedding  # noqa: E402
+from scripts import turso_http as t  # noqa: E402
+
+
+def _missing_count() -> int:
+    return t.execute(
+        "SELECT COUNT(*) AS n FROM score_history "
+        "WHERE embedding IS NULL AND idea_text IS NOT NULL AND length(idea_text) > 0"
+    )[0]["n"]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--batch", type=int, default=512, help="rows per embed+write cycle")
+    ap.add_argument("--limit", type=int, default=0, help="max rows this run (0 = all)")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    if not embeddings_enabled():
+        print("ERROR: OPENAI_API_KEY not set", file=sys.stderr)
+        return 2
+
+    total_missing = _missing_count()
+    cap = total_missing if args.limit == 0 else min(total_missing, args.limit)
+    est = cap * 40
+    print(f"[http-backfill] {total_missing} rows missing embedding; will embed {cap} "
+          f"(~{est:,} tokens, approx ${est / 1_000_000 * 0.02:.4f})")
+    if args.dry_run:
+        return 0
+
+    done = 0
+    started = time.time()
+    while done < cap:
+        take = min(args.batch, cap - done)
+        rows = t.execute(
+            "SELECT id, idea_text FROM score_history "
+            "WHERE embedding IS NULL AND idea_text IS NOT NULL AND length(idea_text) > 0 "
+            "ORDER BY id ASC LIMIT ?",
+            [take],
+        )
+        if not rows:
+            break
+        ids = [r["id"] for r in rows]
+        texts = [r["idea_text"] for r in rows]
+        try:
+            vectors = embed_texts(texts)
+        except EmbeddingError as e:
+            print(f"ERROR embedding batch (ids {ids[0]}..{ids[-1]}): {e}", file=sys.stderr)
+            return 1
+        writes = [
+            ("UPDATE score_history SET embedding=? WHERE id=?", [pack_embedding(v), rid])
+            for rid, v in zip(ids, vectors)
+        ]
+        t.execute_many(writes)
+        done += len(rows)
+        rate = done / max(time.time() - started, 0.001)
+        print(f"[http-backfill] {done}/{cap} (ids {ids[0]}..{ids[-1]}) {rate:.0f} rows/s", flush=True)
+
+    print(f"[http-backfill] done — embedded {done} rows in {time.time() - started:.1f}s; "
+          f"remaining missing = {_missing_count()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/turso_http.py
+++ b/scripts/turso_http.py
@@ -1,0 +1,95 @@
+"""Minimal Turso HTTP client (/v2/pipeline) — bypasses the libsql sync client,
+which hangs on this machine. Used by the embedding backfill and ad-hoc analysis.
+
+Env: TURSO_DATABASE_URL (libsql://… or https://…), TURSO_AUTH_TOKEN.
+Arg types follow Hrana: {"type": "integer|float|text|null|blob", ...}.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Any, Sequence
+
+import httpx
+
+
+def _http_url() -> str:
+    url = os.environ["TURSO_DATABASE_URL"]
+    return url.replace("libsql://", "https://", 1) if url.startswith("libsql://") else url
+
+
+def _to_arg(v: Any) -> dict:
+    if v is None:
+        return {"type": "null"}
+    if isinstance(v, bool):
+        return {"type": "integer", "value": str(int(v))}
+    if isinstance(v, int):
+        return {"type": "integer", "value": str(v)}
+    if isinstance(v, float):
+        return {"type": "float", "value": v}
+    if isinstance(v, (bytes, bytearray)):
+        return {"type": "blob", "base64": base64.b64encode(bytes(v)).decode("ascii")}
+    return {"type": "text", "value": str(v)}
+
+
+def _from_val(cell: dict) -> Any:
+    t = cell.get("type")
+    if t == "null":
+        return None
+    if t == "integer":
+        return int(cell["value"])
+    if t == "float":
+        return float(cell["value"])
+    if t == "blob":
+        return base64.b64decode(cell["base64"])
+    return cell.get("value")
+
+
+def execute(sql: str, args: Sequence[Any] | None = None, *, timeout: float = 60.0) -> list[dict]:
+    """Run one SQL statement. Returns a list of row dicts (empty for writes/DDL)."""
+    stmt: dict = {"sql": sql}
+    if args:
+        stmt["args"] = [_to_arg(a) for a in args]
+    payload = {"requests": [{"type": "execute", "stmt": stmt}, {"type": "close"}]}
+    with httpx.Client(timeout=timeout) as client:
+        resp = client.post(
+            f"{_http_url()}/v2/pipeline",
+            headers={"Authorization": f"Bearer {os.environ['TURSO_AUTH_TOKEN']}"},
+            json=payload,
+        )
+    resp.raise_for_status()
+    result = resp.json()["results"][0]
+    if result.get("type") == "error":
+        raise RuntimeError(f"Turso error: {result['error']}")
+    res = result["response"]["result"]
+    cols = [c["name"] for c in res["cols"]]
+    return [{cols[i]: _from_val(cell) for i, cell in enumerate(row)} for row in res["rows"]]
+
+
+def execute_many(statements: list[tuple[str, Sequence[Any]]], *, timeout: float = 120.0) -> None:
+    """Run many write statements in a single pipeline request (batched UPDATEs)."""
+    reqs: list[dict] = []
+    for sql, args in statements:
+        stmt: dict = {"sql": sql}
+        if args:
+            stmt["args"] = [_to_arg(a) for a in args]
+        reqs.append({"type": "execute", "stmt": stmt})
+    reqs.append({"type": "close"})
+    with httpx.Client(timeout=timeout) as client:
+        resp = client.post(
+            f"{_http_url()}/v2/pipeline",
+            headers={"Authorization": f"Bearer {os.environ['TURSO_AUTH_TOKEN']}"},
+            json={"requests": reqs},
+        )
+    resp.raise_for_status()
+    for r in resp.json()["results"]:
+        if r.get("type") == "error":
+            raise RuntimeError(f"Turso error: {r['error']}")
+
+
+if __name__ == "__main__":
+    import sys
+
+    rows = execute(sys.argv[1] if len(sys.argv) > 1 else "SELECT 1 AS ok")
+    print(rows)

--- a/tests/test_score_history.py
+++ b/tests/test_score_history.py
@@ -16,6 +16,10 @@ def _use_tmp_db(tmp_path, monkeypatch):
     """Use a temporary database for each test."""
     db_path = str(tmp_path / "test_score_history.db")
     monkeypatch.setattr(score_db, "DB_PATH", db_path)
+    # Force the semantic-search matrix to reload every call so the in-memory cache
+    # never leaks one test's embeddings into another's fresh DB.
+    monkeypatch.setattr(score_db, "_EMB_CACHE_TTL", 0.0, raising=False)
+    score_db.invalidate_embedding_cache()
     score_db.init_db()
 
 

--- a/tests/test_score_history.py
+++ b/tests/test_score_history.py
@@ -105,3 +105,73 @@ def test_save_score_returns_incrementing_ids():
         )
         ids.append(row_id)
     assert ids[0] < ids[1] < ids[2]
+
+
+# ---------------------------------------------------------------------------
+# Semantic embeddings (P1)
+# ---------------------------------------------------------------------------
+
+import numpy as np  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from api.embeddings import pack_embedding, unpack_embedding  # noqa: E402
+
+
+def _unit(seed):
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal(1536).astype(np.float32)
+    return (x / np.linalg.norm(x)).tolist()
+
+
+def test_pack_unpack_roundtrip():
+    v = [0.1, -0.2, 0.3, 0.0]
+    assert np.allclose(unpack_embedding(pack_embedding(v)), v, atol=1e-6)
+    assert unpack_embedding(b"") == []
+
+
+def test_embedding_column_added_to_legacy_table(tmp_path, monkeypatch):
+    """init_db must ALTER-in the embedding column on a pre-embedding table."""
+    import sqlite3
+
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE score_history (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "idea_hash TEXT, idea_text TEXT, score INT, breakdown TEXT, keywords TEXT, "
+        "depth TEXT, lang TEXT, keyword_source TEXT, created_at TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(score_db, "DB_PATH", db_path)
+    score_db.init_db()
+    cols = {r[1] for r in sqlite3.connect(db_path).execute("PRAGMA table_info(score_history)").fetchall()}
+    assert "embedding" in cols
+
+
+def test_semantic_search_ranks_paraphrase_first():
+    base = np.asarray(_unit(1), dtype=np.float32)
+    para = base * 0.9 + np.asarray(_unit(2), dtype=np.float32) * 0.1
+    para = (para / np.linalg.norm(para)).tolist()
+    far = _unit(99)
+
+    score_db.save_score("split bills with roommates", 71, "{}", "[]", embedding=pack_embedding(base.tolist()))
+    score_db.save_score("a photo editing tool", 55, "{}", "[]", embedding=pack_embedding(far))
+
+    res = score_db.search_similar_by_embedding(para, limit=5)
+    assert res, "expected at least one match"
+    assert res[0]["idea_text"] == "split bills with roommates"
+    assert res[0]["similarity"] > res[-1]["similarity"]
+
+
+def test_rows_missing_embedding_and_backfill_flow():
+    rid = score_db.save_score("idea without vector", 60, "{}", "[]")
+    missing_ids = [r["id"] for r in score_db.rows_missing_embedding()]
+    assert rid in missing_ids
+    score_db.set_embedding(rid, pack_embedding(_unit(7)))
+    assert rid not in [r["id"] for r in score_db.rows_missing_embedding()]
+
+
+def test_semantic_search_empty_corpus_and_zero_vector():
+    assert score_db.search_similar_by_embedding(_unit(1)) == []  # nothing embedded yet
+    score_db.save_score("something", 50, "{}", "[]", embedding=pack_embedding(_unit(3)))
+    assert score_db.search_similar_by_embedding([0.0] * 1536) == []  # zero query -> []


### PR DESCRIPTION
Replaces keyword-LIKE similarity with semantic embeddings so the scorer catches paraphrased duplicates. Foundation only — backfill run + scorer wiring + demand-heat signal are the next steps (see docs/P1-semantic-embeddings.md).

## What's here
- `api/embeddings.py`: batch embed client (OpenAI text-embedding-3-small, httpx) + float32 BLOB pack/unpack
- `api/db.py`: embedding column (idempotent ALTER for the live table), save_score(embedding=), set_embedding, rows_missing_embedding, count_missing_embedding, search_similar_by_embedding (cosine + graceful [] fallback)
- `scripts/backfill_embeddings.py`: idempotent/resumable backfill (--dry-run/--limit)
- requirements: +numpy
- 5 new tests (12/12 green): roundtrip, legacy-table migration, semantic ranking, backfill flow, empty/zero-vector edges

## Not yet (next phase)
1. Run backfill on prod Turso (needs libsql-client + OPENAI_API_KEY; ~\$0.01)
2. Wire search_similar_by_embedding into /api/check top_similars (keyword fallback)
3. Render deploy + OPENAI_API_KEY env
4. Demand-heat signal (verdict "judgment" -> "navigation")

Does not touch the reality-score formula (explainable log-curve stays).